### PR TITLE
[SA-50173] Fix Client not Bubbling Up HTTP Status Errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"fmt"
 	"net/http"
 )
 
@@ -25,12 +26,7 @@ type (
 	}
 )
 
-const (
-	FailedHTTPRequestErrorMessage = "server returned a non-200 status code"
-)
-
 var (
-
 	// Type assertions
 	_ Error = &RequestError{}
 	_ Error = &ExecutionError{}
@@ -48,11 +44,11 @@ func (r *RequestError) Response() *http.Response {
 }
 
 func (r *RequestError) Error() string {
-	return FailedHTTPRequestErrorMessage
+	return fmt.Sprintf("request failed with status: %s", r.response.Status)
 }
 
 func (r *RequestError) Errors() []string {
-	return []string{FailedHTTPRequestErrorMessage}
+	return []string{r.Error()}
 }
 
 func NewExecutionError(message error) *ExecutionError {

--- a/error.go
+++ b/error.go
@@ -1,0 +1,102 @@
+package graphql
+
+import (
+	"net/http"
+)
+
+type (
+	Error interface {
+		error
+		Response() *http.Response
+		Errors() []string
+	}
+
+	RequestError struct {
+		response *http.Response
+	}
+
+	ExecutionError struct {
+		message error
+	}
+
+	GraphQLError struct {
+		errors   []graphErr
+		response *http.Response
+	}
+)
+
+const (
+	FailedHTTPRequestErrorMessage = "server returned a non-200 status code"
+)
+
+var (
+
+	// Type assertions
+	_ Error = &RequestError{}
+	_ Error = &ExecutionError{}
+	_ Error = &GraphQLError{}
+)
+
+func NewRequestError(response *http.Response) *RequestError {
+	return &RequestError{
+		response: response,
+	}
+}
+
+func (r *RequestError) Response() *http.Response {
+	return r.response
+}
+
+func (r *RequestError) Error() string {
+	return FailedHTTPRequestErrorMessage
+}
+
+func (r *RequestError) Errors() []string {
+	return []string{FailedHTTPRequestErrorMessage}
+}
+
+func NewExecutionError(message error) *ExecutionError {
+	return &ExecutionError{
+		message: message,
+	}
+}
+
+func (e *ExecutionError) Response() *http.Response {
+	return nil
+}
+
+func (e *ExecutionError) Error() string {
+	return e.message.Error()
+}
+
+func (e *ExecutionError) Errors() []string {
+	return []string{e.message.Error()}
+}
+
+func NewGraphQLError(errors []graphErr, response *http.Response) *GraphQLError {
+	return &GraphQLError{
+		errors:   errors,
+		response: response,
+	}
+}
+
+func (g *GraphQLError) Response() *http.Response {
+	return g.response
+}
+
+func (g *GraphQLError) Error() string {
+	if len(g.errors) > 0 {
+		return g.errors[0].Error()
+	}
+
+	return ""
+}
+
+func (g *GraphQLError) Errors() []string {
+	errors := []string{}
+	for _, err := range g.errors {
+		errors = append(errors, err.Error())
+	}
+
+	return errors
+}

--- a/error_test.go
+++ b/error_test.go
@@ -21,7 +21,9 @@ func TestNewRequestError(t *testing.T) {
 
 func TestRequestErrorResponse(t *testing.T) {
 	is := is.New(t)
-	response := &http.Response{}
+	response := &http.Response{
+		Status: http.StatusText(http.StatusNotFound),
+	}
 
 	err := NewRequestError(response)
 
@@ -31,22 +33,26 @@ func TestRequestErrorResponse(t *testing.T) {
 
 func TestRequestErrorError(t *testing.T) {
 	is := is.New(t)
-	response := &http.Response{}
+	response := &http.Response{
+		Status: http.StatusText(http.StatusNotFound),
+	}
 
 	err := NewRequestError(response)
 
 	is.True(err != nil)
-	is.Equal(err.Error(), FailedHTTPRequestErrorMessage)
+	is.Equal(err.Error(), "request failed with status: Not Found")
 }
 
 func TestRequestErrorErrors(t *testing.T) {
 	is := is.New(t)
-	response := &http.Response{}
+	response := &http.Response{
+		Status: http.StatusText(http.StatusNotFound),
+	}
 
 	err := NewRequestError(response)
 
 	is.True(err != nil)
-	is.Equal(err.Errors(), []string{FailedHTTPRequestErrorMessage})
+	is.Equal(err.Errors(), []string{"request failed with status: Not Found"})
 }
 
 func TestNewExecutionError(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,165 @@
+package graphql
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/matryer/is"
+	"github.com/pkg/errors"
+)
+
+func TestNewRequestError(t *testing.T) {
+	is := is.New(t)
+	response := &http.Response{}
+	expected := RequestError{response: response}
+
+	err := NewRequestError(response)
+
+	is.True(err != nil)
+	is.Equal(*err, expected)
+}
+
+func TestRequestErrorResponse(t *testing.T) {
+	is := is.New(t)
+	response := &http.Response{}
+
+	err := NewRequestError(response)
+
+	is.True(err != nil)
+	is.Equal(err.Response(), response)
+}
+
+func TestRequestErrorError(t *testing.T) {
+	is := is.New(t)
+	response := &http.Response{}
+
+	err := NewRequestError(response)
+
+	is.True(err != nil)
+	is.Equal(err.Error(), FailedHTTPRequestErrorMessage)
+}
+
+func TestRequestErrorErrors(t *testing.T) {
+	is := is.New(t)
+	response := &http.Response{}
+
+	err := NewRequestError(response)
+
+	is.True(err != nil)
+	is.Equal(err.Errors(), []string{FailedHTTPRequestErrorMessage})
+}
+
+func TestNewExecutionError(t *testing.T) {
+	is := is.New(t)
+	message := errors.New("some error")
+	expected := ExecutionError{message: message}
+
+	err := NewExecutionError(message)
+
+	is.True(err != nil)
+	is.Equal(*err, expected)
+}
+
+func TestExecutionErrorResponse(t *testing.T) {
+	is := is.New(t)
+	message := errors.New("some error")
+
+	err := NewExecutionError(message)
+
+	is.True(err != nil)
+	is.Equal(err.Response(), nil)
+}
+
+func TestExecutionErrorError(t *testing.T) {
+	is := is.New(t)
+	message := errors.New("some error")
+
+	err := NewExecutionError(message)
+
+	is.True(err != nil)
+	is.Equal(err.Error(), message.Error())
+}
+
+func TestExecutionErrorErrors(t *testing.T) {
+	is := is.New(t)
+	message := errors.New("some error")
+
+	err := NewExecutionError(message)
+
+	is.True(err != nil)
+	is.Equal(err.Errors(), []string{message.Error()})
+}
+
+func TestNewGraphQLError(t *testing.T) {
+	is := is.New(t)
+	graphqlErrors := []graphErr{
+		{Message: "some error"},
+		{Message: "other error"},
+	}
+	response := &http.Response{}
+	expected := GraphQLError{
+		errors:   graphqlErrors,
+		response: response,
+	}
+
+	err := NewGraphQLError(graphqlErrors, response)
+
+	is.True(err != nil)
+	is.Equal(*err, expected)
+}
+
+func TestGraphQLErrorResponse(t *testing.T) {
+	is := is.New(t)
+	graphqlErrors := []graphErr{
+		{Message: "some error"},
+		{Message: "other error"},
+	}
+	response := &http.Response{}
+
+	err := NewGraphQLError(graphqlErrors, response)
+
+	is.True(err != nil)
+	is.Equal(err.Response(), response)
+}
+
+func TestGraphQLErrorError(t *testing.T) {
+	is := is.New(t)
+	graphqlErrors := []graphErr{
+		{Message: "some error"},
+		{Message: "other error"},
+	}
+	response := &http.Response{}
+
+	err := NewGraphQLError(graphqlErrors, response)
+
+	is.True(err != nil)
+	is.Equal(err.Error(), graphqlErrors[0].Error())
+}
+
+func TestGraphQLErrorErrorEmptyList(t *testing.T) {
+	is := is.New(t)
+	graphqlErrors := []graphErr{}
+	response := &http.Response{}
+
+	err := NewGraphQLError(graphqlErrors, response)
+
+	is.True(err != nil)
+	is.Equal(err.Error(), "")
+}
+
+func TestGraphQLErrorErrors(t *testing.T) {
+	is := is.New(t)
+	graphqlErrors := []graphErr{
+		{Message: "some error"},
+		{Message: "other error"},
+	}
+	response := &http.Response{}
+
+	err := NewGraphQLError(graphqlErrors, response)
+
+	is.True(err != nil)
+	is.Equal(err.Errors(), []string{
+		graphqlErrors[0].Error(),
+		graphqlErrors[1].Error(),
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/sumup/graphql
+
+go 1.17
+
+require (
+	github.com/matryer/is v1.4.0
+	github.com/pkg/errors v0.9.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
+github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/graphql.go
+++ b/graphql.go
@@ -137,6 +137,9 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	if err != nil {
 		return err
 	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
+	}
 	defer res.Body.Close()
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, res.Body); err != nil {
@@ -144,9 +147,6 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	}
 	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
-		if res.StatusCode != http.StatusOK {
-			return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
-		}
 		return errors.Wrap(err, "decoding response")
 	}
 	if len(gr.Errors) > 0 {
@@ -208,6 +208,9 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	if err != nil {
 		return err
 	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
+	}
 	defer res.Body.Close()
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, res.Body); err != nil {
@@ -215,9 +218,6 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	}
 	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
-		if res.StatusCode != http.StatusOK {
-			return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
-		}
 		return errors.Wrap(err, "decoding response")
 	}
 	if len(gr.Errors) > 0 {

--- a/graphql.go
+++ b/graphql.go
@@ -87,14 +87,14 @@ func (c *Client) logf(format string, args ...interface{}) {
 // Pass in a nil response object to skip response parsing.
 // If the request fails or the server returns an error, the first error
 // will be returned.
-func (c *Client) Run(ctx context.Context, req *Request, resp interface{}) error {
+func (c *Client) Run(ctx context.Context, req *Request, resp interface{}) Error {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return NewExecutionError(ctx.Err())
 	default:
 	}
 	if len(req.files) > 0 && !c.useMultipartForm {
-		return errors.New("cannot send files with PostFields option")
+		return NewExecutionError(errors.New("cannot send files with PostFields option"))
 	}
 	if c.useMultipartForm {
 		return c.runWithPostFields(ctx, req, resp)
@@ -102,7 +102,7 @@ func (c *Client) Run(ctx context.Context, req *Request, resp interface{}) error 
 	return c.runWithJSON(ctx, req, resp)
 }
 
-func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}) error {
+func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}) Error {
 	var requestBody bytes.Buffer
 	requestBodyObj := struct {
 		Query     string                 `json:"query"`
@@ -112,7 +112,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 		Variables: req.vars,
 	}
 	if err := json.NewEncoder(&requestBody).Encode(requestBodyObj); err != nil {
-		return errors.Wrap(err, "encode body")
+		return NewExecutionError(errors.Wrap(err, "encode body"))
 	}
 	c.logf(">> variables: %v", req.vars)
 	c.logf(">> query: %s", req.q)
@@ -121,7 +121,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	}
 	r, err := http.NewRequest(http.MethodPost, c.endpoint, &requestBody)
 	if err != nil {
-		return err
+		return NewExecutionError(err)
 	}
 	r.Close = c.closeReq
 	r.Header.Set("Content-Type", "application/json; charset=utf-8")
@@ -135,54 +135,53 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	r = r.WithContext(ctx)
 	res, err := c.httpClient.Do(r)
 	if err != nil {
-		return err
+		return NewExecutionError(err)
 	}
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
+		return NewRequestError(res)
 	}
 	defer res.Body.Close()
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, res.Body); err != nil {
-		return errors.Wrap(err, "reading body")
+		return NewExecutionError(errors.Wrap(err, "reading body"))
 	}
 	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
-		return errors.Wrap(err, "decoding response")
+		return NewExecutionError(errors.Wrap(err, "decoding response"))
 	}
 	if len(gr.Errors) > 0 {
-		// return first error
-		return gr.Errors[0]
+		return NewGraphQLError(gr.Errors, res)
 	}
 	return nil
 }
 
-func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp interface{}) error {
+func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp interface{}) Error {
 	var requestBody bytes.Buffer
 	writer := multipart.NewWriter(&requestBody)
 	if err := writer.WriteField("query", req.q); err != nil {
-		return errors.Wrap(err, "write query field")
+		return NewExecutionError(errors.Wrap(err, "write query field"))
 	}
 	var variablesBuf bytes.Buffer
 	if len(req.vars) > 0 {
 		variablesField, err := writer.CreateFormField("variables")
 		if err != nil {
-			return errors.Wrap(err, "create variables field")
+			return NewExecutionError(errors.Wrap(err, "create variables field"))
 		}
 		if err := json.NewEncoder(io.MultiWriter(variablesField, &variablesBuf)).Encode(req.vars); err != nil {
-			return errors.Wrap(err, "encode variables")
+			return NewExecutionError(errors.Wrap(err, "encode variables"))
 		}
 	}
 	for i := range req.files {
 		part, err := writer.CreateFormFile(req.files[i].Field, req.files[i].Name)
 		if err != nil {
-			return errors.Wrap(err, "create form file")
+			return NewExecutionError(errors.Wrap(err, "create form file"))
 		}
 		if _, err := io.Copy(part, req.files[i].R); err != nil {
-			return errors.Wrap(err, "preparing file")
+			return NewExecutionError(errors.Wrap(err, "preparing file"))
 		}
 	}
 	if err := writer.Close(); err != nil {
-		return errors.Wrap(err, "close writer")
+		return NewExecutionError(errors.Wrap(err, "close writer"))
 	}
 	c.logf(">> variables: %s", variablesBuf.String())
 	c.logf(">> files: %d", len(req.files))
@@ -192,7 +191,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	}
 	r, err := http.NewRequest(http.MethodPost, c.endpoint, &requestBody)
 	if err != nil {
-		return err
+		return NewExecutionError(err)
 	}
 	r.Close = c.closeReq
 	r.Header.Set("Content-Type", writer.FormDataContentType())
@@ -206,23 +205,22 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	r = r.WithContext(ctx)
 	res, err := c.httpClient.Do(r)
 	if err != nil {
-		return err
+		return NewExecutionError(err)
 	}
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("graphql: server returned a non-200 status code: %v", res.StatusCode)
+		return NewRequestError(res)
 	}
 	defer res.Body.Close()
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, res.Body); err != nil {
-		return errors.Wrap(err, "reading body")
+		return NewExecutionError(errors.Wrap(err, "reading body"))
 	}
 	c.logf("<< %s", buf.String())
 	if err := json.NewDecoder(&buf).Decode(&gr); err != nil {
-		return errors.Wrap(err, "decoding response")
+		return NewExecutionError(errors.Wrap(err, "decoding response"))
 	}
 	if len(gr.Errors) > 0 {
-		// return first error
-		return gr.Errors[0]
+		return NewGraphQLError(gr.Errors, res)
 	}
 	return nil
 }

--- a/graphql_json_test.go
+++ b/graphql_json_test.go
@@ -63,8 +63,8 @@ func TestDoJSONServerError(t *testing.T) {
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
 	is.Equal(calls, 1) // calls
-	is.Equal(err.Error(), "server returned a non-200 status code")
-	is.Equal(err.Errors(), []string{"server returned a non-200 status code"})
+	is.Equal(err.Error(), "request failed with status: 500 Internal Server Error")
+	is.Equal(err.Errors(), []string{"request failed with status: 500 Internal Server Error"})
 	is.Equal(err.Response().StatusCode, http.StatusInternalServerError)
 }
 

--- a/graphql_json_test.go
+++ b/graphql_json_test.go
@@ -75,7 +75,7 @@ func TestDoJSONBadRequestErr(t *testing.T) {
 		b, err := ioutil.ReadAll(r.Body)
 		is.NoErr(err)
 		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, `{
 			"errors": [{
 				"message": "miscellaneous message as to why the the request was bad"

--- a/graphql_multipart_test.go
+++ b/graphql_multipart_test.go
@@ -148,7 +148,7 @@ func TestDoBadRequestErr(t *testing.T) {
 		is.Equal(r.Method, http.MethodPost)
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, `{
 			"errors": [{
 				"message": "miscellaneous message as to why the the request was bad"

--- a/graphql_multipart_test.go
+++ b/graphql_multipart_test.go
@@ -145,8 +145,8 @@ func TestDoServerErr(t *testing.T) {
 	defer cancel()
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
-	is.Equal(err.Error(), "server returned a non-200 status code")
-	is.Equal(err.Errors(), []string{"server returned a non-200 status code"})
+	is.Equal(err.Error(), "request failed with status: 500 Internal Server Error")
+	is.Equal(err.Errors(), []string{"request failed with status: 500 Internal Server Error"})
 	is.Equal(err.Response().StatusCode, http.StatusInternalServerError)
 }
 

--- a/graphql_multipart_test.go
+++ b/graphql_multipart_test.go
@@ -99,9 +99,14 @@ func TestDoErr(t *testing.T) {
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
 		_, _ = io.WriteString(w, `{
-			"errors": [{
-				"message": "Something went wrong"
-			}]
+			"errors": [
+				{
+					"message": "miscellaneous message as to why the the request was bad"
+				},
+				{
+					"message": "secondary message"
+				}
+			]
 		}`)
 	}))
 	defer srv.Close()
@@ -114,7 +119,10 @@ func TestDoErr(t *testing.T) {
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
 	is.True(err != nil)
-	is.Equal(err.Error(), "graphql: Something went wrong")
+	is.Equal(err.Errors(), []string{
+		"graphql: miscellaneous message as to why the the request was bad",
+		"graphql: secondary message",
+	})
 }
 
 func TestDoServerErr(t *testing.T) {
@@ -137,7 +145,9 @@ func TestDoServerErr(t *testing.T) {
 	defer cancel()
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
-	is.Equal(err.Error(), "graphql: server returned a non-200 status code: 500")
+	is.Equal(err.Error(), "server returned a non-200 status code")
+	is.Equal(err.Errors(), []string{"server returned a non-200 status code"})
+	is.Equal(err.Response().StatusCode, http.StatusInternalServerError)
 }
 
 func TestDoBadRequestErr(t *testing.T) {
@@ -150,9 +160,14 @@ func TestDoBadRequestErr(t *testing.T) {
 		is.Equal(query, `query {}`)
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, `{
-			"errors": [{
-				"message": "miscellaneous message as to why the the request was bad"
-			}]
+			"errors": [
+				{
+					"message": "miscellaneous message as to why the the request was bad"
+				},
+				{
+					"message": "secondary message"
+				}
+			]
 		}`)
 	}))
 	defer srv.Close()
@@ -165,6 +180,11 @@ func TestDoBadRequestErr(t *testing.T) {
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
 	is.Equal(err.Error(), "graphql: miscellaneous message as to why the the request was bad")
+	is.Equal(err.Errors(), []string{
+		"graphql: miscellaneous message as to why the the request was bad",
+		"graphql: secondary message",
+	})
+	is.Equal(err.Response().StatusCode, http.StatusOK)
 }
 
 func TestDoNoResponse(t *testing.T) {


### PR DESCRIPTION
Previously, our client would yield no errors when receiving HTTP Errors from our api-gateway. since its response would be a valid "GraphQL response" (a JSON like `{"status": 401}`). This would happen because our client's HTTP status check used to be inside our payload parsing errors, but since our gateway was returning a valid message, there would be no parsing errors and, therefore, no errors at all.

Also, add a mod-file to the project, so that it can be run by our contributors.

Further can be seen in: https://sumup.slack.com/archives/C02FK4DMTJM/p1633527552013900