### PR TITLE
[BBO-283] Removes code and graphql key from log messages

### DIFF
--- a/error.go
+++ b/error.go
@@ -47,18 +47,12 @@ var (
 )
 
 func (e GraphErr) Error() string {
-	code := e.ErrCode()
 	message := e.Message
-
-	if len(code) > 0 {
-		message = message + " code: " + code
-	}
-
 	if len(e.Path) > 0 {
 		return e.ErrPath() + ": " + message
 	}
 
-	return "graphql: " + message
+	return message
 }
 
 func (e GraphErr) ErrCode() string {

--- a/graphql_json_test.go
+++ b/graphql_json_test.go
@@ -298,9 +298,9 @@ func TestDoJSONMutationErr(t *testing.T) {
 	`)
 	err := client.Run(ctx, mutation, &responseData)
 	is.Equal(calls, 1) // calls
-	is.Equal(err.Error(), "graphql: An error occurred code: internal_server_error")
+	is.Equal(err.Error(), "An error occurred")
 	is.Equal(err.Errors(), []string{
-		"graphql: An error occurred code: internal_server_error",
+		"An error occurred",
 	})
 	is.Equal(err.Response().StatusCode, http.StatusOK)
 }

--- a/graphql_multipart_test.go
+++ b/graphql_multipart_test.go
@@ -117,7 +117,7 @@ func TestDoErr(t *testing.T) {
 	err := client.Run(ctx, NewRequest("query {}"), &responseData)
 	is.True(err != nil)
 	is.Equal(err.Errors(), []string{
-		"graphql: miscellaneous message as to why the the request was bad",
+		"miscellaneous message as to why the the request was bad",
 	})
 }
 
@@ -172,9 +172,9 @@ func TestDoBadRequestErr(t *testing.T) {
 	defer cancel()
 	var responseData map[string]interface{}
 	err := client.Run(ctx, NewRequest("query {}"), &responseData)
-	is.Equal(err.Error(), "graphql: miscellaneous message as to why the the request was bad")
+	is.Equal(err.Error(), "miscellaneous message as to why the the request was bad")
 	is.Equal(err.Errors(), []string{
-		"graphql: miscellaneous message as to why the the request was bad",
+		"miscellaneous message as to why the the request was bad",
 	})
 	is.Equal(err.Response().StatusCode, http.StatusOK)
 }


### PR DESCRIPTION
## Motivation

Removing the code and the unecessary graphql key from the message allow us to expose a better message to the client, since sometimes this messages can contain special instructions that can be shown to the user.

`GraphErr` Already exposes methods for getting the code and path, so we can build the message back or use the information isolated if we want to. 